### PR TITLE
Fix: center and size icons on dashboard and features cards(#38)

### DIFF
--- a/app/dashboard/dashboard-content.tsx
+++ b/app/dashboard/dashboard-content.tsx
@@ -135,7 +135,7 @@ export default function DashboardContent() {
                   className="glassmorphic p-6 rounded-xl border-foreground/10 hover:border-foreground/30 transition-all duration-300 cursor-pointer scale-in"
                   style={{ animationDelay: `${idx * 100}ms` }}
                 >
-                  <div className="mb-3">{item.icon}</div>
+                  <div className="inline-flex items-center justify-center w-12 h-12 bg-foreground/10 rounded-lg mb-3">{item.icon}</div>
                   <h3 className="text-lg font-semibold text-foreground mb-1">{item.title}</h3>
                   <p className="text-sm text-muted-foreground">{item.description}</p>
                 </div>

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -65,7 +65,7 @@ export default function Features() {
             const Icon = feature.icon
             const CardContent = (
               <>
-                <div className="inline-flex p-3 bg-foreground/10 rounded-lg mb-4">
+                <div className="inline-flex items-center justify-center w-12 h-12 bg-foreground/10 rounded-lg mb-4">
                   <Icon className="w-6 h-6 text-foreground" />
                 </div>
                 <h3 className="text-xl font-bold text-foreground mb-2">{feature.title}</h3>


### PR DESCRIPTION
Centered and standardized icon size across all dashboard and features cards for a clean, consistent UI.

<img width="1358" height="596" alt="image" src="https://github.com/user-attachments/assets/5ba84ec4-019e-428b-b360-e57fcf155edd" />

