### PR TITLE
fixed header

### DIFF
--- a/app/(web)/leaderboard/page.tsx
+++ b/app/(web)/leaderboard/page.tsx
@@ -1,7 +1,5 @@
-"use client"
+"use client";
 
-import Header from "@/components/header"
-import Footer from "@/components/footer"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -56,7 +54,6 @@ const achievements = [
 export default function LeaderboardPage() {
   return (
     <main className="bg-background min-h-screen">
-      <Header />
 
       {/* Hero Section */}
       <section className="py-20 px-4">


### PR DESCRIPTION
**Issue resolved #118** 

**The issue has been fixed. The duplicate top navigation bar on the Leaderboard page has been removed, and only a single navigation header is now rendered as expected. This restores proper visual layout and improves overall user experience.**

Before :
<img width="1919" height="288" alt="image" src="https://github.com/user-attachments/assets/6e24cb11-8d89-4533-aee5-0bfdc79266d6" />

After :
<img width="1919" height="196" alt="image" src="https://github.com/user-attachments/assets/c846d930-7dc8-470c-87a9-a38c4d343d62" />

@mansi066 Please review the changes and merge this PR 
